### PR TITLE
Fix for WhatsApp Mexico numbers with 521 as prefix

### DIFF
--- a/03-rag-agent-bedrock/layers/common/python/utils.py
+++ b/03-rag-agent-bedrock/layers/common/python/utils.py
@@ -45,7 +45,9 @@ def normalize_phone(phone):
     ### Country specific changes required on phone numbers
     
     ### Mexico specific, remove 1 after 52
-    if(phone[0:2]=='52' and phone[2] == '1'):
+    if(phone[0:3]=='+52' and phone[3] == '1'):
+        normalized = phone[0:3] + phone[4:]
+    elif(phone[0:2]=='52' and phone[2] == '1'):
         normalized = phone[0:2] + phone[3:]
     else:
         normalized  = phone


### PR DESCRIPTION
Fix for WhatsApp Mexico numbers with 521 as prefix

*Issue #, if available:*

*Description of changes:*
03-rag-agent-bedrock/layers/common/python/utils.py: Change in the function normalize_phone to consider the scenarios with "+" as prefix in the international phone number from Mexico. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
